### PR TITLE
Initialize React Vite scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+/dist
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# challenge-arena
+# UI Challenge Arena
+
+Base project created with [Vite](https://vitejs.dev/) and React. Uses
+[Semantic UI React](https://react.semantic-ui.com/) for basic styling.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Building
+
+```bash
+npm run build
+```
+
+## Testing
+
+```bash
+npm test
+```
+
+## Project Structure
+
+- `index.html` - entry HTML used by Vite.
+- `src/` - React source code.
+  - `main.jsx` - mounts the React app.
+  - `App.jsx` - root component.
+  - `components/` - reusable components will go here.
+- `vite.config.js` - Vite configuration.
+- `jest.config.cjs` - Jest configuration for tests.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>UI Challenge Arena</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "challenge-arena",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "semantic-ui-react": "^2.1.4",
+    "semantic-ui-css": "^2.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^3.1.0",
+    "vite": "^4.3.9",
+    "jest": "^29.5.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const App = () => {
+  return (
+    <div className="app">
+      <h1>UI Challenge Arena</h1>
+    </div>
+  );
+};
+
+export default App;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import 'semantic-ui-css/semantic.min.css';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold React project using Vite
- add Semantic UI and basic entry components
- configure Jest for future tests

## Testing
- `npm test` *(fails: jest not found)*